### PR TITLE
adapt DROP to theta usage in FRASER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ script:
   - wbuild --version
   - python --version
 
-  - pytest -vv -s
+  - travis_wait 40 pytest -vv -s

--- a/drop/modules/aberrant-splicing-pipeline/Counting/02_psi_value_calculation_FraseR.R
+++ b/drop/modules/aberrant-splicing-pipeline/Counting/02_psi_value_calculation_FraseR.R
@@ -12,8 +12,8 @@
 #'   - counting_done: '`sm cfg.getProcessedDataDir() + 
 #'                "/aberrant_splicing/datasets/savedObjects/raw-{dataset}/counting.done" `'
 #'  output:
-#'  - psiSS:     '`sm cfg.getProcessedDataDir() + 
-#'                    "/aberrant_splicing/datasets/savedObjects/raw-{dataset}/psiSite.h5"`'
+#'  - theta:     '`sm cfg.getProcessedDataDir() +
+#'                    "/aberrant_splicing/datasets/savedObjects/raw-{dataset}/theta.h5"`'
 #'  type: script
 #'--- 
 

--- a/drop/modules/aberrant-splicing-pipeline/Counting/03_filter_expression_FraseR.R
+++ b/drop/modules/aberrant-splicing-pipeline/Counting/03_filter_expression_FraseR.R
@@ -8,8 +8,8 @@
 #'   - setup: '`sm cfg.AS.getWorkdir() + "/config.R"`'
 #'   - workingDir: '`sm cfg.getProcessedDataDir() + "/aberrant_splicing/datasets/"`'
 #'  input:
-#'   - psiSS:  '`sm cfg.getProcessedDataDir()+ 
-#'                  "/aberrant_splicing/datasets/savedObjects/raw-{dataset}/psiSite.h5"`'
+#'   - theta:  '`sm cfg.getProcessedDataDir()+
+#'                  "/aberrant_splicing/datasets/savedObjects/raw-{dataset}/theta.h5"`'
 #'  output:
 #'   - fds: '`sm cfg.getProcessedDataDir() +
 #'                "/aberrant_splicing/datasets/savedObjects/{dataset}/fds-object.RDS"`'

--- a/drop/modules/aberrant-splicing-pipeline/Counting/Summary.R
+++ b/drop/modules/aberrant-splicing-pipeline/Counting/Summary.R
@@ -34,7 +34,7 @@ fds <- loadFraserDataSet(dir=workingDir, name=paste0("raw-", dataset))
 #' 
 #' Number of introns (psi5 or psi3): `r length(rowRanges(fds, type = "psi5"))`
 #' 
-#' Number of splice sites (psiSite): `r length(rowRanges(fds, type = "psiSite"))`
+#' Number of splice sites (theta): `r length(rowRanges(fds, type = "theta"))`
 #' 
 #' Introns that passed filter
 table(mcols(fds, type="j")[,"passed"])

--- a/drop/modules/aberrant-splicing-pipeline/FRASER/05_fit_autoencoder_FraseR.R
+++ b/drop/modules/aberrant-splicing-pipeline/FRASER/05_fit_autoencoder_FraseR.R
@@ -13,7 +13,7 @@
 #'                "/aberrant_splicing/datasets/savedObjects/{dataset}/hyper.done" `'
 #'  output:
 #'   - fdsout: '`sm cfg.getProcessedDataDir() + 
-#'                  "/aberrant_splicing/datasets/savedObjects/{dataset}/predictedMeans_psiSite.h5"`'
+#'                  "/aberrant_splicing/datasets/savedObjects/{dataset}/predictedMeans_theta.h5"`'
 #'  type: script
 #'---
 

--- a/drop/modules/aberrant-splicing-pipeline/FRASER/06_calculation_stats_AE_FraseR.R
+++ b/drop/modules/aberrant-splicing-pipeline/FRASER/06_calculation_stats_AE_FraseR.R
@@ -11,11 +11,11 @@
 #'  input:
 #'   - fdsin:  '`sm cfg.getProcessedDataDir() + 
 #'                  "/aberrant_splicing/datasets/savedObjects/{dataset}/" +
-#'                  "predictedMeans_psiSite.h5"`'
+#'                  "predictedMeans_theta.h5"`'
 #'  output:
 #'   - fdsout: '`sm cfg.getProcessedDataDir() + 
 #'                  "/aberrant_splicing/datasets/savedObjects/{dataset}/" +
-#'                  "padjBetaBinomial_psiSite.h5"`'
+#'                  "padjBetaBinomial_theta.h5"`'
 #'  type: script
 #'---
 

--- a/drop/modules/aberrant-splicing-pipeline/FRASER/07_extract_results_FraseR.R
+++ b/drop/modules/aberrant-splicing-pipeline/FRASER/07_extract_results_FraseR.R
@@ -15,7 +15,7 @@
 #'   - add_HPO_cols: '`sm str(projectDir / ".drop" / "helpers" / "add_HPO_cols.R")`'
 #'   - fdsin: '`sm cfg.getProcessedDataDir() +
 #'                 "/aberrant_splicing/datasets/savedObjects/{dataset}/" +
-#'                 "padjBetaBinomial_psiSite.h5"`'
+#'                 "padjBetaBinomial_theta.h5"`'
 #'  output:
 #'   - resultTableJunc: '`sm cfg.getProcessedDataDir() + 
 #'                          "/aberrant_splicing/results/{dataset}_results_per_junction.tsv"`'

--- a/drop/modules/aberrant-splicing-pipeline/FRASER/Summary.R
+++ b/drop/modules/aberrant-splicing-pipeline/FRASER/Summary.R
@@ -10,7 +10,7 @@
 #'  input:
 #'   - fdsin: '`sm cfg.getProcessedDataDir() + 
 #'                 "/aberrant_splicing/datasets/savedObjects/{dataset}/" + 
-#'                 "padjBetaBinomial_psiSite.h5"`'
+#'                 "padjBetaBinomial_theta.h5"`'
 #'   - results: '`sm cfg.getProcessedDataDir() + 
 #'                   "/aberrant_splicing/results/{dataset}_results.tsv"`'
 #'  output:
@@ -36,7 +36,7 @@ fds <- loadFraserDataSet(dir=workingDir, name=dataset)
 #' 
 #' Number of introns (psi5 or psi3): `r length(rowRanges(fds, type = "psi5"))`
 #' 
-#' Number of splice sites (psiSite): `r length(rowRanges(fds, type = "psiSite"))`
+#' Number of splice sites (theta): `r length(rowRanges(fds, type = "theta"))`
 
 # used for most plots
 dataset_title <- paste("Dataset:", dataset)
@@ -78,7 +78,7 @@ for(type in psiTypes){
     )
     before
     after <- plotCountCorHeatmap(
-        fds = fds,
+        fds,
         type = type,
         logit = TRUE,
         topN = topN,

--- a/drop/requirementsR.txt
+++ b/drop/requirementsR.txt
@@ -1,6 +1,6 @@
 package bioconductor version
 OUTRIDER TRUE 
-c-mertes/FRASER TRUE 1.1.1
+c-mertes/FRASER TRUE 1.2.0
 mumichae/tMAE TRUE 
 VariantAnnotation TRUE 
 rmarkdown FALSE 

--- a/tests/pipeline/test_AS.py
+++ b/tests/pipeline/test_AS.py
@@ -27,6 +27,6 @@ class Test_AS_Pipeline:
     def test_results(self, demo_dir):
         results_dir = "Output/processed_data/aberrant_splicing/results"
         r = run(f"wc -l {results_dir}/fraser_results_per_junction.tsv", demo_dir)
-        assert "88 " in r.stdout
+        assert "87 " in r.stdout
         r = run(f"wc -l {results_dir}/fraser_results.tsv", demo_dir)
         assert "1 " in r.stdout


### PR DESCRIPTION
As we moved to `theta` from `psiSite` in FRASER, the DROP pipeline needed to be adapted to it. 