### PR TITLE
remove file extension in outrider module

### DIFF
--- a/drop/modules/aberrant-expression-pipeline/OUTRIDER/runOutrider.R
+++ b/drop/modules/aberrant-expression-pipeline/OUTRIDER/runOutrider.R
@@ -24,6 +24,7 @@ suppressPackageStartupMessages({
     library(data.table)
     library(dplyr)
     library(magrittr)
+    library(tools)
 })
 
 ods <- readRDS(snakemake@input$ods)
@@ -55,7 +56,7 @@ message("outrider fitting finished")
 
 # Save the new ods with a date stamp
 op <- snakemake@output$ods
-op_date <- paste0(strsplit(op, "\\.")[[1]][1], "-", format(Sys.time(), "%Y%m%d") , ".Rds")
+op_date <- paste0(file_path_sans_ext(op), "-", format(Sys.time(), "%Y%m%d") , ".Rds")
 saveRDS(ods, op_date)
 
 # Create a link to the previous file


### PR DESCRIPTION
Hi! 
First of all, thanks for a very exciting pipeline! We're looking into running it here at the Clinical Genomics facility in Stockholm. I had an issue with one module when running your demo on our HPC cluster. All users on the cluster have a dot in their username. So when you split a path on 'dot' and use the first part to construct the new filename the path doesn't exist (if that makes sense). I don't know if you accept external PR's, but this is one way to solve my issue.
Cheers,
Anders
 