### PR TITLE
MAE expecting `gene_type` in GTF

### DIFF
--- a/drop/modules/mae-pipeline/MAE/gene_name_mapping.R
+++ b/drop/modules/mae-pipeline/MAE/gene_name_mapping.R
@@ -24,6 +24,8 @@ gtf_dt <- import(snakemake@input$gtf) %>% as.data.table
 if (!"gene_name" %in% colnames(gtf_dt)) {
   gtf_dt[gene_name := gene_id]
 }
+if('gene_biotype' %in% colnames(gtf_dt))
+   setnames(gtf_dt, 'gene_biotype', 'gene_type')
 gtf_dt <- gtf_dt[type == "gene", .(seqnames, start, end, strand, gene_id, gene_name, gene_type)]
 
 # make gene_names unique


### PR DESCRIPTION
Hello!
Thank you for developing this pipeline. I'm very excited to use this for all my RNA samples!
I ran into another issue similar to [this](https://github.com/gagneurlab/drop/issues/133#issuecomment-726125985) with the GTF file using `gene_biotype` instead of expected `gene_type`. 

I was using the dev branch commit cfe6dbd5d7b03f2e3c33e240283277c7e4d61a90 running the whole pipeline (`snakemake --cores 6`)
Error message:
```
Error in eval(jsub, SDenv, parent.frame()) : object 'gene_type' not found
Calls: [ -> [.data.table -> eval -> eval
Execution halted
[Thu Feb  4 00:37:26 2021]
Error in rule MonoallelicExpression_pipeline_MAE_gene_name_mapping_R:
    jobid: 113
    output: /scratch1/fs1/fcole/work/drop/run/conda/out/processed_data/mae/gene_name_mapping_v95.tsv
    log: /scratch1/fs1/fcole/work/drop/run/conda/.drop/tmp/MAE/v95.Rds (check log file(s) for error message)

RuleException:
CalledProcessError in line 291 of /tmp/127888.tmpdir/tmpvtnx6mvd:
Command 'set -euo pipefail;  Rscript --vanilla /scratch1/fs1/fcole/work/drop/run/conda/.snakemake/scripts/tmp1fkqdwmr.gene_name_mapping.R' returned non-zero exit status 1.
  File "/opt/conda/envs/drop/lib/python3.9/site-packages/snakemake/executors/__init__.py", line 2319, in run_wrapper
  File "/tmp/127888.tmpdir/tmpvtnx6mvd", line 291, in __rule_MonoallelicExpression_pipeline_MAE_gene_name_mapping_R
  File "/opt/conda/envs/drop/lib/python3.9/site-packages/snakemake/executors/__init__.py", line 568, in _callback
  File "/opt/conda/envs/drop/lib/python3.9/concurrent/futures/thread.py", line 52, in run
  File "/opt/conda/envs/drop/lib/python3.9/site-packages/snakemake/executors/__init__.py", line 554, in cached_or_run
  File "/opt/conda/envs/drop/lib/python3.9/site-packages/snakemake/executors/__init__.py", line 2350, in run_wrapper
```
This PR uses the [same method](https://github.com/gagneurlab/drop/blob/dev/drop/modules/aberrant-expression-pipeline/Counting/preprocessGeneAnnotation.R#L45-L46) of swapping `gene_biotype` to `gene_type` in the MAE module. 

After making this change I was able to get MAE to generate the result tsvs(`snakemake --cores 6 -k`). I have not been able to get the whole pipeline to succeed as a few jobs continue to fail. I expect this is because of the dot graph [issues](https://github.com/gagneurlab/drop/issues/121#issuecomment-732143911)
