### PR TITLE
Fix dependency graph fails

### DIFF
--- a/drop/modules/aberrant-expression-pipeline/Snakefile
+++ b/drop/modules/aberrant-expression-pipeline/Snakefile
@@ -13,7 +13,12 @@ rule aberrantExpression:
 
 rule aberrantExpression_dependency:
     output: AE_graph_file
-    shell: "snakemake --nolock --rulegraph {AE_index_output} | dot -Tsvg -Grankdir=TB > {output}"
+    shell:
+        """
+        snakemake --nolock --rulegraph {AE_index_output} | \
+            sed -n '/digraph snakemake_dag/,$p' | \
+            dot -Tsvg -Grankdir=TB > {output}
+        """
 
 rule aberrantExpression_bamStats:
     input: 

--- a/drop/modules/aberrant-expression-pipeline/Snakefile
+++ b/drop/modules/aberrant-expression-pipeline/Snakefile
@@ -16,7 +16,7 @@ rule aberrantExpression_dependency:
     shell:
         """
         snakemake --nolock --rulegraph {AE_index_output} | \
-            sed -n '/digraph snakemake_dag/,$p' | \
+            sed -ne '/digraph snakemake_dag/,/}}/p' | \
             dot -Tsvg -Grankdir=TB > {output}
         """
 

--- a/drop/modules/aberrant-splicing-pipeline/Snakefile
+++ b/drop/modules/aberrant-splicing-pipeline/Snakefile
@@ -13,4 +13,9 @@ rule aberrantSplicing:
 
 rule aberrantSplicing_dependency:
     output: AS_graph_file
-    shell: "snakemake --nolock --rulegraph {AS_index_output} | dot -Tsvg -Grankdir=TB > {output}"
+    shell:
+        """
+        snakemake --nolock --rulegraph {AS_index_output} | \
+            sed -n '/digraph snakemake_dag/,$p' | \
+            dot -Tsvg -Grankdir=TB > {output}
+        """

--- a/drop/modules/aberrant-splicing-pipeline/Snakefile
+++ b/drop/modules/aberrant-splicing-pipeline/Snakefile
@@ -16,6 +16,6 @@ rule aberrantSplicing_dependency:
     shell:
         """
         snakemake --nolock --rulegraph {AS_index_output} | \
-            sed -n '/digraph snakemake_dag/,$p' | \
+            sed -ne '/digraph snakemake_dag/,/}}/p' | \
             dot -Tsvg -Grankdir=TB > {output}
         """

--- a/drop/modules/mae-pipeline/Snakefile
+++ b/drop/modules/mae-pipeline/Snakefile
@@ -16,7 +16,7 @@ rule mae_dependency:
     shell:
         """
         snakemake --nolock --rulegraph {MAE_index_output} | \
-            sed -n '/digraph snakemake_dag/,$p' | \
+            sed -ne '/digraph snakemake_dag/,/}}/p' | \
             dot -Tsvg -Grankdir=TB > {output}
         """
 

--- a/drop/modules/mae-pipeline/Snakefile
+++ b/drop/modules/mae-pipeline/Snakefile
@@ -13,7 +13,12 @@ rule mae:
 
 rule mae_dependency:
     output: MAE_graph_file
-    shell: "snakemake --nolock --rulegraph {MAE_index_output} | dot -Tsvg -Grankdir=TB > {output}"
+    shell:
+        """
+        snakemake --nolock --rulegraph {MAE_index_output} | \
+            sed -n '/digraph snakemake_dag/,$p' | \
+            dot -Tsvg -Grankdir=TB > {output}
+        """
 
 rule sampleQC:
     input: cfg.getHtmlFromScript(MAE_WORKDIR / "QC" / "Datasets.R")


### PR DESCRIPTION
Dependency graph fails, as soon as any output is printed to standard out beforehand. This pull request filers the rulegraph output, so that prior output doesn't mess up the graph generation.