### PR TITLE
Foolproof snakemake

### DIFF
--- a/drop/download_data.sh
+++ b/drop/download_data.sh
@@ -3,7 +3,7 @@ set -e
 
 # get data
 resource_url="https://www.cmm.in.tum.de/public/paper/drop_analysis/resource.tar.gz"
-tmpdir="$(dirname "$(tempfile)")"
+tmpdir="$(dirname "$(mktemp)")"
 wget -nc -P $tmpdir $resource_url
 mkdir -p Data
 if [ -z "$(ls Data)" ]; then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def demo_dir(tmpdir_factory):
 def dropConfig(demo_dir):
     orig_path = os.getcwd()
     os.chdir(demo_dir)
-    with patch.object(sys, 'argv', ["snakemake", "-n"]):
+    with patch.object(sys, 'argv', ["snakemake", "-n", "--cores 1"]):
         cfg = drop.config.DropConfig(wbuild.utils.Config())
     os.chdir(orig_path)
     return cfg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from .common import *
 
 
-@pytest.yield_fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def demo_dir(tmpdir_factory):
     """
     Directory containing files downloaded from Gagneurlab ready to run the demo pipeline

--- a/tests/pipeline/test_AE.py
+++ b/tests/pipeline/test_AE.py
@@ -6,8 +6,7 @@ class Test_AE_Pipeline:
     @pytest.fixture(scope="class")
     def pipeline_run(self, demo_dir):
         LOGGER.info("run aberrant expression pipeline...")
-        pipeline_run = run(["snakemake", "aberrantExpression", f"-j{CORES}"], demo_dir)
-        tmp = run(["snakemake", "--unlock"], demo_dir)
+        pipeline_run = run(f"snakemake aberrantExpression --cores {CORES}", demo_dir)
         assert "Finished job 0." in pipeline_run.stderr
         return pipeline_run
 
@@ -74,12 +73,12 @@ class Test_AE_Pipeline:
 
     def test_no_import(self, no_import):
         merged_counts = f"{no_import}/Output/processed_data/aberrant_expression/v29/outrider/outrider/total_counts.Rds"
-        r = run(f"snakemake {merged_counts} --configfile config_noimp.yaml -nqF", no_import)
-        tmp = run(["snakemake", "--unlock"], no_import)
-        
-        print(r.stdout)
-        assert "10\tAberrantExpression_pipeline_Counting_countReads_R" in r.stdout
-        assert "1\tAberrantExpression_pipeline_Counting_mergeCounts_R" in r.stdout
+        # check dryrun
+        r = run(f"snakemake {merged_counts} --configfile config_noimp.yaml -nF --cores 1", no_import)
+
+        # check if new rules are included in snakemake output
+        assert "AberrantExpression_pipeline_Counting_countReads_R" in r.stdout
+        assert "AberrantExpression_pipeline_Counting_mergeCounts_R" in r.stdout
 
         # check if pipeline runs through without errors
-        run(f"snakemake {merged_counts} --configfile config_noimp.yaml -j{CORES}", no_import)
+        run(f"snakemake {merged_counts} --configfile config_noimp.yaml --cores {CORES}", no_import)

--- a/tests/pipeline/test_AS.py
+++ b/tests/pipeline/test_AS.py
@@ -6,8 +6,8 @@ class Test_AS_Pipeline:
     @pytest.fixture(scope="class")
     def pipeline_run(self, demo_dir):
         LOGGER.info("run aberrant splicing pipeline")
-        pipeline_run = run(["snakemake", "aberrantSplicing", f"-j{CORES}"], demo_dir)
-        tmp = run(["snakemake", "--unlock"], demo_dir)
+        pipeline_run = run(f"snakemake aberrantSplicing --cores {CORES}", demo_dir)
+
         assert "Finished job 0." in pipeline_run.stderr
         return pipeline_run
   

--- a/tests/pipeline/test_MAE.py
+++ b/tests/pipeline/test_MAE.py
@@ -6,8 +6,7 @@ class Test_MAE_Pipeline:
     @pytest.fixture(scope="class")
     def pipeline_run(self, demo_dir):
         LOGGER.info("run MAE pipeline")
-        pipeline_run = run(["snakemake", "mae", f"-j{CORES}"], demo_dir)
-        tmp = run(["snakemake", "--unlock"], demo_dir)
+        pipeline_run = run(f"snakemake mae --cores {CORES}", demo_dir)
         assert "Finished job 0." in pipeline_run.stderr
         return pipeline_run
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -2,7 +2,7 @@ from tests.common import *
 
 
 def test_dryrun(demo_dir):
-    r = run(["snakemake", "-n --cores 1"], dir_path=demo_dir)
+    r = run("snakemake -n --cores 1", dir_path=demo_dir)
     message = "This was a dry-run (flag -n). The order of jobs does not reflect the order of execution."
     assert message in r.stdout
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -2,29 +2,29 @@ from tests.common import *
 
 
 def test_dryrun(demo_dir):
-    r = run(["snakemake", "-n"], dir_path=demo_dir)
+    r = run(["snakemake", "-n --cores 1"], dir_path=demo_dir)
     message = "This was a dry-run (flag -n). The order of jobs does not reflect the order of execution."
     assert message in r.stdout
 
 
 def test_dependencyGraph(demo_dir):
-    r = run(["snakemake", "dependencyGraph", "-Fj"], dir_path=demo_dir)
+    r = run(f"snakemake dependencyGraph -F --cores {CORES}", dir_path=demo_dir)
     assert "aberrantExpression_dependency" in r.stderr
     assert "aberrantSplicing_dependency" in r.stderr
     assert "mae_dependency" in r.stderr
     assert "Finished job 0." in r.stderr
     # clean HTML output
-    r = run(["snakemake", "clean", f"-j{CORES}"], dir_path=demo_dir)
+    r = run(f"snakemake clean --cores {CORES}", dir_path=demo_dir)
     assert "clean" in r.stderr
     assert "Finished job 0." in r.stderr
 
 
 def test_export(demo_dir):
-    r = run(["snakemake", "exportCounts", f"-j{CORES}"], demo_dir)
+    r = run(f"snakemake exportCounts --cores {CORES}", demo_dir)
     assert "Finished job 0." in r.stderr
 
 
 @pytest.mark.trylast
 def test_all(demo_dir):
-    r = run(["snakemake", f"-j{CORES}"], demo_dir)
+    r = run(f"snakemake --cores {CORES}", demo_dir)
     assert "Finished job 0." in r.stderr


### PR DESCRIPTION
New version of snakemake (6.5.0) forces the use of cores for every statement. This causes the test to fail.