### PR TITLE
Fix bam stats wildcards

### DIFF
--- a/drop/modules/aberrant-expression-pipeline/Counting/Summary.R
+++ b/drop/modules/aberrant-expression-pipeline/Counting/Summary.R
@@ -7,8 +7,7 @@
 #'  input: 
 #'    - ods: '`sm cfg.getProcessedResultsDir() +
 #'            "/aberrant_expression/{annotation}/outrider/{dataset}/ods_unfitted.Rds"`'
-#'    - bam_cov: '`sm cfg.getProcessedDataDir() +
-#'                "/aberrant_expression/{annotation}/outrider/{dataset}/bam_coverage.tsv"`'
+#'    - bam_cov: '`sm rules.aberrantExpression_mergeBamStats.output`'
 #'  output:
 #'   - wBhtml: '`sm config["htmlOutputPath"] +
 #'              "/AberrantExpression/Counting/{annotation}/Summary_{dataset}.html"`'

--- a/drop/modules/aberrant-expression-pipeline/Snakefile
+++ b/drop/modules/aberrant-expression-pipeline/Snakefile
@@ -22,7 +22,7 @@ rule aberrantExpression_bamStats:
         bam = lambda wildcards: sa.getFilePath(wildcards.sampleID, "RNA_BAM_FILE"),
         ucsc2ncbi =AE_WORKDIR / "resource" / "chr_UCSC_NCBI.txt"
     output:
-        cfg.processedDataDir / "aberrant_expression" / "{annotation}" / "coverage" / "{sampleID}.tsv"
+        cfg.processedDataDir / "aberrant_expression" / "bam_stats" / "{sampleID}.txt"
     params:
         samtools = config["tools"]["samtoolsCmd"]
     shell:
@@ -44,11 +44,12 @@ rule aberrantExpression_bamStats:
 
 rule aberrantExpression_mergeBamStats:
     input:
-        lambda w: expand(cfg.getProcessedDataDir() +
-            "/aberrant_expression/{{annotation}}/coverage/{sampleID}.tsv",
-            sampleID=sa.getIDsByGroup(w.dataset), assay="RNA")
+        lambda w: expand(
+            rules.aberrantExpression_bamStats.output[0],
+            sampleID=sa.getIDsByGroup(w.dataset, assay="RNA")
+        )
     output:
-        cfg.getProcessedDataDir() + "/aberrant_expression/{annotation}/outrider/{dataset}/bam_coverage.tsv"
+        cfg.processedDataDir / "aberrant_expression" / "bam_stats" / "{dataset}.tsv"
     params:
         exIDs = lambda w: sa.getIDsByGroup(w.dataset, assay="GENE_COUNT")
     run:


### PR DESCRIPTION
**Problem:** BAM coverage is annotation independent, however it is redundantly recomputed for each new annotation.

**Solution:** Removing `annotation` wildcard from BAM stats rules to avoid unnecessary computations.