### PR TITLE
Fix sample parameter ID matching

### DIFF
--- a/drop/config/SampleParams.py
+++ b/drop/config/SampleParams.py
@@ -178,8 +178,8 @@ class SampleParams:
 
             # replace any strings of nan with "NA"
             current_SA = sa_df.loc[sa_df["RNA_ID"].isin(ID),param_cols].reset_index(drop = True)
-            current_SA = current_SA.replace("nan","NA").fillna(value = "NA")
-            old_SA = pd.read_csv(true_filename).reset_index(drop = True).fillna(value = "NA")
+            current_SA = current_SA.replace("nan","NA").fillna(value = "NA").astype(str)
+            old_SA = pd.read_csv(true_filename).reset_index(drop = True).fillna(value = "NA").astype(str)
 
             if current_SA.equals(old_SA):
                 pass

--- a/environment.yml
+++ b/environment.yml
@@ -10,4 +10,4 @@ dependencies:
   - bioconductor-bsgenome.hsapiens.ucsc.hg19
   - samtools>=1.9
   - bcftools>=1.9
-  - wbuild>1.8
+  - wbuild>=1.8

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,6 @@ dependencies:
   - drop
   - flake8
   - bioconductor-bsgenome.hsapiens.ucsc.hg19
+  - samtools>=1.9
+  - bcftools>=1.9
+  - wbuild>1.8

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,3 @@ dependencies:
   - drop
   - flake8
   - bioconductor-bsgenome.hsapiens.ucsc.hg19
-  - samtools>=1.9
-  - bcftools>=1.9
-  - wbuild>=1.8


### PR DESCRIPTION
Problem: For datasets where sample IDs are numerical, DROP wants to rerun these samples.
Fix: Resolve ambiguity for integer sample IDs.
