### PR TITLE
Update to MAE filter scripts

### DIFF
--- a/drop/modules/mae-pipeline/MAE/ASEReadCounter.sh
+++ b/drop/modules/mae-pipeline/MAE/ASEReadCounter.sh
@@ -45,6 +45,19 @@ fi
 chr_subset=$(comm -12 <(cut -f1 -d" " ${canonical} | sort -u) <(echo "${vcf_chr}"))
 chr_subset=$(comm -12 <(echo "${bam_chr}") <(echo "${chr_subset}") | uniq)
 
+# ASEReadCounter fails without RG, this snippet checks for RG in bam file
+# and if RG tag isn't present, lets the user know how to fix it
+if samtools view -H ${bam_file} | grep -q "@RG";then
+  printf "BAM contains RG, continuing with ASEReadCounter...\n"
+else
+  printf "%s\n" "" "ERROR: BAM file doesn't contain Read Group Tag" \
+  " RG doesn't exist, it can be added using -" \
+  "   gatk AddOrReplaceGroups -R /path/to/reference -I /your/input.bam -O /your/output.bam --QUIET true" \
+  " Try rerunning this module using the BAM with RG tags"
+  exit 1
+fi
+
+
 for chr in $chr_subset; do
   $gatk ASEReadCounter \
     -R ${fasta} \

--- a/drop/modules/mae-pipeline/MAE/filterSNVs.sh
+++ b/drop/modules/mae-pipeline/MAE/filterSNVs.sh
@@ -49,11 +49,12 @@ fi
 # view the vcf file and remove the info header information and the set the INFO column to '.'
 # split any multi-allelic lines
 # pull out the sample and only the snps that have at least 2 reads supporting it
+# Using bcftools -Ou to speed up processing
 $bcftools view  $vcf_file -r $canonical_chr | \
     grep -vP '^##INFO=' | \
     awk -F'\t' 'BEGIN {OFS = FS} { if($1 ~ /^[^#]/){ $8 = "." }; print $0 }' | \
-    $bcftools norm -m-both | \
-    $bcftools norm -d both | \
+    $bcftools norm -Ou -m-both | \
+    $bcftools norm -Ou -d both | \
     $bcftools view ${sample_flag} -m2 -M2 -v snps > $tmp
 
 # use the select_pattern defined above to pull out the heterozygous variants used for MAE


### PR DESCRIPTION
Upon testing, the MAE module fails if there is no ```RG``` tag in the input BAM file. Since the demo files have ```RG``` tag, I've written a small QC for the same. If the tag isn't present, the tool quits before running ```gatk ASEReadCounter``` and lets the user know how to add ```RG``` to the BAM file.

In the file ```filter_SNVs.sh``` I've included the ```-Ou``` switch. The bcftools documentation recommends using this switch when piping between bcftools.