### PR TITLE
Fix typo in exportCounts input

### DIFF
--- a/drop/modules/aberrant-splicing-pipeline/Counting/exportCounts.R
+++ b/drop/modules/aberrant-splicing-pipeline/Counting/exportCounts.R
@@ -10,7 +10,7 @@
 #'  input:
 #'   - annotation: '`sm cfg.getProcessedDataDir() + "/preprocess/{annotation}/txdb.db"`'
 #'   - fds_theta: '`sm cfg.getProcessedDataDir() + 
-#'                    "/aberrant_splicing/datasets/savedObjects/raw-{dataset}/theta.h5"`'
+#'                    "/aberrant_splicing/datasets/savedObjects/raw-local-{dataset}/theta.h5"`'
 #'  output:
 #'    - k_counts: '`sm expand(cfg.exportCounts.getFilePattern(str_=True, expandStr=True) + "/k_{metric}_counts.tsv.gz", metric=["j", "theta"])`'
 #'    - n_counts: '`sm expand(cfg.exportCounts.getFilePattern(str_=True, expandStr=True) + "/n_{metric}_counts.tsv.gz", metric=["psi5", "psi3", "theta"])`'


### PR DESCRIPTION
Rename raw-{dataset} to raw-local-{dataset}. There is no rule that produces raw-{dataset} as output.

This fixes a MissingInputException when running `exportCounts` without having a populated SPLICE_COUNTS_DIR, such as when using BCM UDN blood samples (https://doi.org/10.5281/zenodo.3963470):

```
% snakemake -n exportCounts    
WARNING: 64 files missing in samples annotation. Ignoring...
check for missing R packages
MonoallelicExpression has been turned off in the config file
rnaVariantCalling has been turned off in the config file
Structuring dependencies...
Dependencies file generated at: /tmp/tmps8kl_ksp

Building DAG of jobs...
MissingInputException in line 192 of /tmp/tmps8kl_ksp:
Missing input files for rule AberrantSplicing_pipeline_Counting_exportCounts_R:
    output: OutputRev/processed_results/exported_counts/Blood--hg19--gencode34/k_j_counts.tsv.gz, OutputRev/processed_results/exported_counts/Blood--hg19--gencode34/k_theta_counts.tsv.gz, OutputRev/processed_results/exported_counts/Blood--hg19--gencode34/n_psi5_counts.tsv.gz, OutputRev/processed_results/exported_counts/Blood--hg19--gencode34/n_psi3_counts.tsv.gz, OutputRev/processed_results/exported_counts/Blood--hg19--gencode34/n_theta_counts.tsv.gz
    wildcards: dataset=Blood, genomeAssembly=hg19, annotation=gencode34
    affected files:
        OutputRev/processed_data/aberrant_splicing/datasets/savedObjects/raw-Blood/theta.h5	
```