### PR TITLE
Adds space between `#+` and `echo`

### DIFF
--- a/drop/modules/mae-pipeline/MAE/Results.R
+++ b/drop/modules/mae-pipeline/MAE/Results.R
@@ -107,7 +107,7 @@ res[, MAE_ALT := MAE == TRUE & altRatio >= allelicRatioCutoff]
 #'
 #' Number of samples with significant MAE for alternative events: `r uniqueN(res[MAE_ALT == TRUE, ID])`
 
-#+echo=F
+#+ echo=F
 
 # Save full results zipped
 res[, altRatio := round(altRatio, 3)]

--- a/drop/modules/mae-pipeline/QC/DNA_RNA_matrix_plot.R
+++ b/drop/modules/mae-pipeline/QC/DNA_RNA_matrix_plot.R
@@ -12,7 +12,7 @@
 #'  type: noindex
 #'---
 
-#+echo=F
+#+ echo=F
 saveRDS(snakemake, snakemake@log$snakemake)
 
 suppressPackageStartupMessages({

--- a/drop/template/Scripts/MonoallelicExpression/Overview.R
+++ b/drop/template/Scripts/MonoallelicExpression/Overview.R
@@ -86,7 +86,7 @@ qc_links <- sapply(qc_groups, function(v) build_link_list(
 #'
 
 #' ## Analyze Individual Results
-#+echo=FALSE
+#+ echo=FALSE
 # Read the first results table
 res_sample <- readRDS(snakemake@input$results_sample[[1]])
 sample <- unique(res_sample$ID)
@@ -95,7 +95,7 @@ library(tMAE)
 library(ggplot2)
 rare_column <- 'rare'
 if(any(is.na(res_sample$rare))) rare_column <- NULL
-#+echo=TRUE
+#+ echo=TRUE
 
 #' ### MA plot: fold change vs RNA coverage
 plotMA4MAE(res_sample, rare_column = rare_column,

--- a/drop/template/Scripts/Pipeline/SampleAnnotation.R
+++ b/drop/template/Scripts/Pipeline/SampleAnnotation.R
@@ -16,7 +16,7 @@
 #'    code_download: TRUE
 #'---
 
-#+echo=F
+#+ echo=F
 saveRDS(snakemake, snakemake@log$snakemake)
 
 suppressPackageStartupMessages({
@@ -76,7 +76,7 @@ unique(sa[,.(RNA_ID, DROP_GROUP)])$DROP_GROUP %>% strsplit(',') %>% unlist %>%
   table %>% barplot(xlab = 'DROP groups', ylab = 'Number of samples')
 
 # Obtain genes that overlap with HPO terms
-#+echo=F
+#+ echo=F
 if(!is.null(sa$HPO_TERMS) & !all(is.na(sa$HPO_TERMS)) & ! all(sa$HPO_TERMS == '')){
   sa2 <- sa[, .SD[1], by = RNA_ID]
   


### PR DESCRIPTION
Fixes: https://github.com/gagneurlab/drop/issues/532

As described in the issue, there recent versions of `knitr` wrongly converted `#+argument` comments without a space before the argumnet into `{rargument}`. Adding a space fixes this.