### PR TITLE
Adapt to new FRASER version and fix minor issues

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push,pull_request]
 
 jobs:
   build-linux:

--- a/drop/config/SampleAnnotation.py
+++ b/drop/config/SampleAnnotation.py
@@ -47,6 +47,11 @@ class SampleAnnotation:
         optional_columns = {"GENE_COUNTS_FILE", "SPLICE_COUNTS_DIR", "GENE_ANNOTATION", "GENOME"}
 
         annotationTable = pd.read_csv(self.file, sep=sep, index_col=False)
+        
+        # FRASER cannot handle a mixture of stranded and unstranded samples, raise error in such cases
+        if (annotationTable['STRAND'] == 'no').any() & ((annotationTable['STRAND'] == 'reverse').any() | (annotationTable['STRAND'] == 'yes').any()):
+            raise ValueError("Data contains a mix of stranded and unstranded samples. Please consider analyzing them separately.\n")
+
         missing_cols = [x for x in self.SAMPLE_ANNOTATION_COLUMNS if x not in annotationTable.columns.values]
         if len(missing_cols) > 0:
             if "GENE_ANNOTATION" in missing_cols and "ANNOTATION" in annotationTable.columns.values:

--- a/drop/config/SampleAnnotation.py
+++ b/drop/config/SampleAnnotation.py
@@ -50,7 +50,10 @@ class SampleAnnotation:
         
         # FRASER cannot handle a mixture of stranded and unstranded samples, raise error in such cases
         if (annotationTable['STRAND'] == 'no').any() & ((annotationTable['STRAND'] == 'reverse').any() | (annotationTable['STRAND'] == 'yes').any()):
-            raise ValueError("Data contains a mix of stranded and unstranded samples. Please consider analyzing them separately.\n")
+            raise ValueError("Data contains a mix of stranded and unstranded samples. Please analyze them separately.\n")
+        
+        if annotationTable['STRAND'].isnull().values.any():
+            raise ValueError("STRAND is not provided for some samples. All samples should have STRAND value in the sample annotation file.\n")
 
         missing_cols = [x for x in self.SAMPLE_ANNOTATION_COLUMNS if x not in annotationTable.columns.values]
         if len(missing_cols) > 0:

--- a/drop/demo/sample_annotation_relative.tsv
+++ b/drop/demo/sample_annotation_relative.tsv
@@ -1,15 +1,15 @@
 RNA_ID	RNA_BAM_FILE	DNA_VCF_FILE	DNA_ID	DROP_GROUP	PAIRED_END	COUNT_MODE	COUNT_OVERLAPS	STRAND	HPO_TERMS	GENE_COUNTS_FILE	GENE_ANNOTATION	GENOME	SPLICE_COUNTS_DIR
-HG00096	Data/rna_bam/HG00096_ncbi.bam	Data/dna_vcf/demo_chr21_ncbi.vcf.gz	HG00096	outrider,fraser,mae,batch_0	True	IntersectionStrict	True	no	HP:0009802,HP:0010896			ncbi	
-HG00103	Data/rna_bam/HG00103.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00103	outrider,fraser,mae,batch_1	True	IntersectionStrict	True	no	HP:0004582,HP:0031959			ucsc	
-HG00106	Data/rna_bam/HG00106.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00106	outrider,outrider_external,fraser,fraser_external,mae,batch_1	True	IntersectionStrict	True	no	HP:0002895,HP:0006731			ucsc	
-HG00111	Data/rna_bam/HG00111.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00111	outrider,outrider_external,fraser,fraser_external	True	IntersectionStrict	True	no	HP:0100491,HP:0100871				
-HG00116	Data/rna_bam/HG00116.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00116	outrider,outrider_external,fraser,fraser_external	True	IntersectionStrict	True	no	HP:0030613,HP:0012767				
-HG00126	Data/rna_bam/HG00126.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00126	outrider,outrider_external,fraser,fraser_external	True	IntersectionStrict	True	no	HP:0000290,HP:0000293				
-HG00132	Data/rna_bam/HG00132.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00132	outrider,outrider_external,fraser,fraser_external	True	IntersectionStrict	True	no	HP:0006489,HP:0006490				
-HG00149	Data/rna_bam/HG00149.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00149	outrider,outrider_external,fraser,fraser_external	True	IntersectionStrict	True	no	HP:0000014,HP:0000020,HP:0032663				
-HG00150	Data/rna_bam/HG00150.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00150	outrider,outrider_external,fraser,fraser_external	True	IntersectionStrict	True	no	HP:0030809,HP:0006144				
-HG00176	Data/rna_bam/HG00176.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00176	outrider,outrider_external,fraser,fraser_external	True	IntersectionStrict	True	no	HP:0005215,HP:0010234				
-HG00178				outrider_external						Data/external_count_data/geneCounts.tsv.gz	v29		
-HG00181				outrider_external						Data/external_count_data/geneCounts.tsv.gz	v29		
-HG00191				fraser_external									Data/external_count_data
-HG00201				fraser_external									Data/external_count_data
+HG00096	Data/rna_bam/HG00096_ncbi.bam	Data/dna_vcf/demo_chr21_ncbi.vcf.gz	HG00096	outrider,fraser,mae,batch_0	TRUE	IntersectionStrict	TRUE	no	HP:0009802,HP:0010896			ncbi	
+HG00103	Data/rna_bam/HG00103.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00103	outrider,fraser,mae,batch_1	TRUE	IntersectionStrict	TRUE	no	HP:0004582,HP:0031959			ucsc	
+HG00106	Data/rna_bam/HG00106.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00106	outrider,outrider_external,fraser,fraser_external,mae,batch_1	TRUE	IntersectionStrict	TRUE	no	HP:0002895,HP:0006731			ucsc	
+HG00111	Data/rna_bam/HG00111.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00111	outrider,outrider_external,fraser,fraser_external	TRUE	IntersectionStrict	TRUE	no	HP:0100491,HP:0100871				
+HG00116	Data/rna_bam/HG00116.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00116	outrider,outrider_external,fraser,fraser_external	TRUE	IntersectionStrict	TRUE	no	HP:0030613,HP:0012767				
+HG00126	Data/rna_bam/HG00126.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00126	outrider,outrider_external,fraser,fraser_external	TRUE	IntersectionStrict	TRUE	no	HP:0000290,HP:0000293				
+HG00132	Data/rna_bam/HG00132.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00132	outrider,outrider_external,fraser,fraser_external	TRUE	IntersectionStrict	TRUE	no	HP:0006489,HP:0006490				
+HG00149	Data/rna_bam/HG00149.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00149	outrider,outrider_external,fraser,fraser_external	TRUE	IntersectionStrict	TRUE	no	HP:0000014,HP:0000020,HP:0032663				
+HG00150	Data/rna_bam/HG00150.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00150	outrider,outrider_external,fraser,fraser_external	TRUE	IntersectionStrict	TRUE	no	HP:0030809,HP:0006144				
+HG00176	Data/rna_bam/HG00176.bam	Data/dna_vcf/demo_chr21.vcf.gz	HG00176	outrider,outrider_external,fraser,fraser_external	TRUE	IntersectionStrict	TRUE	no	HP:0005215,HP:0010234				
+HG00178				outrider_external				no		Data/external_count_data/geneCounts.tsv.gz	v29		
+HG00181				outrider_external				no		Data/external_count_data/geneCounts.tsv.gz	v29		
+HG00191				fraser_external				no					Data/external_count_data
+HG00201				fraser_external				no					Data/external_count_data

--- a/drop/installRPackages.R
+++ b/drop/installRPackages.R
@@ -23,18 +23,20 @@ if (file.exists(args[1])){
         package=gsub("=.*", "", unlist(args)),
         version=gsub(".*=", "", unlist(args)),
         ref="")
-    packages[package == version, version:=NA]
+    packages[package == version, c("min_version", "max_version") := ""]
 }
 installed <- as.data.table(installed.packages())
 
 for (pckg_name in packages$package) {
     package_dt <- packages[package == pckg_name]
     pckg_name <- gsub(".*/", "", pckg_name)
-    version <- package_dt$version
+    min_version <- package_dt$min_version
+    max_version <- package_dt$max_version
     branch <- package_dt$ref
     
-    if (!pckg_name %in% installed$Package || (!is.na(version) && compareVersion(
-        installed[Package == pckg_name, Version], version) < 0)) {
+    if (!pckg_name %in% installed$Package || (min_version != "" && (compareVersion(
+      installed[Package == pckg_name, Version], min_version) < 0 || compareVersion(
+        installed[Package == pckg_name, Version], max_version) > 0))) {
         
         package <- package_dt$package
         message(paste("install", package))

--- a/drop/installRPackages.R
+++ b/drop/installRPackages.R
@@ -23,20 +23,18 @@ if (file.exists(args[1])){
         package=gsub("=.*", "", unlist(args)),
         version=gsub(".*=", "", unlist(args)),
         ref="")
-    packages[package == version, c("min_version", "max_version") := ""]
+    packages[package == version, version:=NA]
 }
 installed <- as.data.table(installed.packages())
 
 for (pckg_name in packages$package) {
     package_dt <- packages[package == pckg_name]
     pckg_name <- gsub(".*/", "", pckg_name)
-    min_version <- package_dt$min_version
-    max_version <- package_dt$max_version
+    version <- package_dt$version
     branch <- package_dt$ref
     
-    if (!pckg_name %in% installed$Package || (min_version != "" && (compareVersion(
-      installed[Package == pckg_name, Version], min_version) < 0 || compareVersion(
-        installed[Package == pckg_name, Version], max_version) > 0))) {
+    if (!pckg_name %in% installed$Package || (!is.na(version) && compareVersion(
+        installed[Package == pckg_name, Version], version) < 0)) {
         
         package <- package_dt$package
         message(paste("install", package))

--- a/drop/modules/aberrant-splicing-pipeline/Counting/01_0_countRNA_init.R
+++ b/drop/modules/aberrant-splicing-pipeline/Counting/01_0_countRNA_init.R
@@ -35,10 +35,7 @@ fds <- FraserDataSet(colData = col_data,
 
 # Add paired end and strand specificity to the fds
 pairedEnd(fds) <- colData(fds)$PAIRED_END
-strandSpecific(fds) <- 'no'
-if(uniqueN(colData(fds)$STRAND) == 1){
-  strandSpecific(fds) <- unique(colData(fds)$STRAND)
-} 
+strandSpecific(fds) <- colData(fds)$STRAND
 
 # Save initial FRASER dataset
 fds <- saveFraserDataSet(fds)

--- a/drop/modules/aberrant-splicing-pipeline/Counting/01_0_countRNA_init.R
+++ b/drop/modules/aberrant-splicing-pipeline/Counting/01_0_countRNA_init.R
@@ -29,6 +29,8 @@ params <- snakemake@config$aberrantSplicing
 # Create initial FRASER object
 col_data <- fread(colDataFile)
 
+col_data$strand <- 0L
+
 fds <- FraserDataSet(colData = col_data,
                      workingDir = workingDir,
                      name       = paste0("raw-local-", dataset))

--- a/drop/modules/aberrant-splicing-pipeline/Counting/01_1_countRNA_splitReads_samplewise.R
+++ b/drop/modules/aberrant-splicing-pipeline/Counting/01_1_countRNA_splitReads_samplewise.R
@@ -35,7 +35,7 @@ sample_id <- snakemake@wildcards[["sample_id"]]
 
 # If data is not strand specific, add genome info
 genome <- NULL
-if(strandSpecific(fds) == 0){
+if(strandSpecific(fds[, sample_id]) == 0){
   genome <- getBSgenome(genomeAssembly)
 }
 

--- a/drop/modules/aberrant-splicing-pipeline/Counting/03_filter_expression_FraseR.R
+++ b/drop/modules/aberrant-splicing-pipeline/Counting/03_filter_expression_FraseR.R
@@ -53,7 +53,9 @@ if(length(exCountIDs) > 0){
     for(resource in unique(exCountFiles)){
         exSampleIDs <- exCountIDs[exCountFiles == resource]
         exAnno <- fread(sample_anno_file, key="RNA_ID")[J(exSampleIDs)]
-        exAnno$strand <- as.integer(0)
+        exAnno[, strand:=exAnno$STRAND]
+        exAnno$strand<- sapply(exAnno[, strand], switch, 'no' = 0L, 'unstranded' = 0L, 
+                                   'yes' = 1L, 'stranded' = 1L, 'reverse' = 2L, -1L)
         setnames(exAnno, "RNA_ID", "sampleID")
         
         ctsNames <- c("k_j", "k_theta", "n_psi3", "n_psi5", "n_theta")

--- a/drop/modules/aberrant-splicing-pipeline/Counting/03_filter_expression_FraseR.R
+++ b/drop/modules/aberrant-splicing-pipeline/Counting/03_filter_expression_FraseR.R
@@ -53,6 +53,7 @@ if(length(exCountIDs) > 0){
     for(resource in unique(exCountFiles)){
         exSampleIDs <- exCountIDs[exCountFiles == resource]
         exAnno <- fread(sample_anno_file, key="RNA_ID")[J(exSampleIDs)]
+        exAnno$strand <- as.integer(0)
         setnames(exAnno, "RNA_ID", "sampleID")
         
         ctsNames <- c("k_j", "k_theta", "n_psi3", "n_psi5", "n_theta")

--- a/drop/modules/aberrant-splicing-pipeline/FRASER/08_extract_results_FraseR.R
+++ b/drop/modules/aberrant-splicing-pipeline/FRASER/08_extract_results_FraseR.R
@@ -52,8 +52,6 @@ res_junc <- results(fds, psiType=psiTypes,
 res_junc_dt   <- as.data.table(res_junc)
 print('Results per junction extracted')
 
-names(colData(fds))[which(names(colData(fds))=="strand")] <- "intSTRAND"
-
 # Add features
 if(nrow(res_junc_dt) > 0){
 
@@ -73,9 +71,6 @@ if(nrow(res_junc_dt) > 0){
     res_junc_dt[, numEventsPerGene := .N, by = "hgncSymbol,sampleID"]
     res_junc_dt[, numSamplesPerJunc := uniqueN(sampleID), by = "seqnames,start,end,strand"]
     
-    # add colData to the results
-    res_junc_dt <- merge(res_junc_dt, as.data.table(colData(fds)), by = "sampleID")
-    res_junc_dt[, c("bamFile", "pairedEnd", "intSTRAND", "STRAND", "RNA_BAM_FILE", "DNA_VCF_FILE", "COUNT_MODE", "COUNT_OVERLAPS") := NULL]
 } else{
     warning("The aberrant splicing pipeline gave 0 intron-level results for the ", dataset, " dataset.")
 }
@@ -105,9 +100,6 @@ res_genes_dt <- res_genes_dt[do.call(pmin, c(res_genes_dt[,padj_cols, with=FALSE
                                     totalCounts >= 5,]
 
 if(nrow(res_genes_dt) > 0){
-    res_genes_dt <- merge(res_genes_dt, as.data.table(colData(fds)), by = "sampleID")
-    res_genes_dt[, c("bamFile", "pairedEnd", "intSTRAND", "STRAND", "RNA_BAM_FILE", "DNA_VCF_FILE", "COUNT_MODE", "COUNT_OVERLAPS") := NULL]
-
     # add HPO overlap information
     sa <- fread(snakemake@config$sampleAnnotation, 
                 colClasses = c(RNA_ID = 'character', DNA_ID = 'character'))

--- a/drop/modules/aberrant-splicing-pipeline/FRASER/08_extract_results_FraseR.R
+++ b/drop/modules/aberrant-splicing-pipeline/FRASER/08_extract_results_FraseR.R
@@ -52,6 +52,8 @@ res_junc <- results(fds, psiType=psiTypes,
 res_junc_dt   <- as.data.table(res_junc)
 print('Results per junction extracted')
 
+names(colData(fds))[which(names(colData(fds))=="strand")] <- "intSTRAND"
+
 # Add features
 if(nrow(res_junc_dt) > 0){
 
@@ -73,7 +75,7 @@ if(nrow(res_junc_dt) > 0){
     
     # add colData to the results
     res_junc_dt <- merge(res_junc_dt, as.data.table(colData(fds)), by = "sampleID")
-    res_junc_dt[, c("bamFile", "pairedEnd", "STRAND", "RNA_BAM_FILE", "DNA_VCF_FILE", "COUNT_MODE", "COUNT_OVERLAPS") := NULL]
+    res_junc_dt[, c("bamFile", "pairedEnd", "intSTRAND", "STRAND", "RNA_BAM_FILE", "DNA_VCF_FILE", "COUNT_MODE", "COUNT_OVERLAPS") := NULL]
 } else{
     warning("The aberrant splicing pipeline gave 0 intron-level results for the ", dataset, " dataset.")
 }
@@ -104,7 +106,7 @@ res_genes_dt <- res_genes_dt[do.call(pmin, c(res_genes_dt[,padj_cols, with=FALSE
 
 if(nrow(res_genes_dt) > 0){
     res_genes_dt <- merge(res_genes_dt, as.data.table(colData(fds)), by = "sampleID")
-    res_genes_dt[, c("bamFile", "pairedEnd", "STRAND", "RNA_BAM_FILE", "DNA_VCF_FILE", "COUNT_MODE", "COUNT_OVERLAPS") := NULL]
+    res_genes_dt[, c("bamFile", "pairedEnd", "intSTRAND", "STRAND", "RNA_BAM_FILE", "DNA_VCF_FILE", "COUNT_MODE", "COUNT_OVERLAPS") := NULL]
 
     # add HPO overlap information
     sa <- fread(snakemake@config$sampleAnnotation, 

--- a/drop/modules/aberrant-splicing-pipeline/FRASER/08_extract_results_FraseR.R
+++ b/drop/modules/aberrant-splicing-pipeline/FRASER/08_extract_results_FraseR.R
@@ -54,23 +54,10 @@ print('Results per junction extracted')
 
 # Add features
 if(nrow(res_junc_dt) > 0){
-
-    # dcast to have one row per outlier
-    subsets <- res_junc_dt[, unique(FDR_set)]
-    subsets <- subsets[subsets != "transcriptome-wide"]
-    colorder <- colnames(res_junc_dt[, !"FDR_set", with=FALSE])
-    res_junc_dt <- dcast(res_junc_dt, ... ~ FDR_set, value.var="padjust")
-    setnames(res_junc_dt, "transcriptome-wide", "padjust")
-    for(subset_name in subsets){
-        setnames(res_junc_dt, subset_name, paste0("padjust_", subset_name))
-    }
-    setcolorder(res_junc_dt, colorder)
-    
     # number of samples per gene and variant
     res_junc_dt[, numSamplesPerGene := uniqueN(sampleID), by = hgncSymbol]
     res_junc_dt[, numEventsPerGene := .N, by = "hgncSymbol,sampleID"]
     res_junc_dt[, numSamplesPerJunc := uniqueN(sampleID), by = "seqnames,start,end,strand"]
-    
 } else{
     warning("The aberrant splicing pipeline gave 0 intron-level results for the ", dataset, " dataset.")
 }
@@ -80,15 +67,6 @@ res_gene <- results(fds, psiType=psiTypes,
                     aggregate=TRUE, collapse=FALSE,
                     all=TRUE)
 res_genes_dt   <- as.data.table(res_gene)
-subsets <- res_genes_dt[, unique(FDR_set)]
-subsets <- subsets[subsets != "transcriptome-wide"]
-colorder <- colnames(res_genes_dt[, !c("padjust", "FDR_set"), with=FALSE])
-res_genes_dt <- dcast(res_genes_dt[,!"padjust", with=FALSE], ... ~ FDR_set, value.var="padjustGene")
-setnames(res_genes_dt, "transcriptome-wide", "padjustGene")
-for(subset_name in subsets){
-    setnames(res_genes_dt, subset_name, paste0("padjustGene_", subset_name))
-}
-setcolorder(res_genes_dt, colorder)
 print('Results per gene extracted')
 write_tsv(res_genes_dt, file=snakemake@output$resultTableGene_full)
 

--- a/drop/modules/mae-pipeline/MAE/Results.R
+++ b/drop/modules/mae-pipeline/MAE/Results.R
@@ -107,7 +107,7 @@ res[, MAE_ALT := MAE == TRUE & altRatio >= allelicRatioCutoff]
 #'
 #' Number of samples with significant MAE for alternative events: `r uniqueN(res[MAE_ALT == TRUE, ID])`
 
-#+echo=F
+#+ echo=F
 
 # Save full results zipped
 res[, altRatio := round(altRatio, 3)]

--- a/drop/modules/mae-pipeline/QC/DNA_RNA_matrix_plot.R
+++ b/drop/modules/mae-pipeline/QC/DNA_RNA_matrix_plot.R
@@ -12,7 +12,7 @@
 #'  type: noindex
 #'---
 
-#+echo=F
+#+ echo=F
 saveRDS(snakemake, snakemake@log$snakemake)
 
 suppressPackageStartupMessages({

--- a/drop/modules/mae-pipeline/Snakefile
+++ b/drop/modules/mae-pipeline/Snakefile
@@ -20,19 +20,6 @@ rule mae_dependency:
 rule sampleQC:
     input: cfg.getHtmlFromScript(MAE_WORKDIR / "QC" / "Datasets.R")
 
-rule create_dict:
-    input:  cfg.genome.getFastaList()
-    output:  cfg.genome.getDictList()
-    shell: 
-	    """
-		for fasta in {input}
-		  do
-		  if [ ! -f "${{fasta%.*}}.dict" ]; then
-		    gatk CreateSequenceDictionary --REFERENCE $fasta
-                  fi
-		done
-		"""
-
 
 ## MAE
 rule mae_createSNVs:

--- a/drop/requirementsR.txt
+++ b/drop/requirementsR.txt
@@ -1,8 +1,8 @@
-package	version	ref
+package	min_version	max_version	ref
 devtools
-gagneurlab/OUTRIDER	1.17.2	HEAD
-gagneurlab/FRASER	1.99.1	HEAD
-gagneurlab/tMAE	1.0.4	HEAD
+gagneurlab/OUTRIDER	1.17.2	1.17.2	HEAD
+gagneurlab/FRASER	1.99.1	1.99.3	HEAD
+gagneurlab/tMAE	1.0.4	1.0.4	HEAD
 VariantAnnotation		
 rmarkdown		
 knitr		

--- a/drop/requirementsR.txt
+++ b/drop/requirementsR.txt
@@ -1,8 +1,8 @@
 package	version	ref
 devtools
-gagneurlab/OUTRIDER	1.22.0	HEAD
-gagneurlab/FRASER	2.0.0	HEAD
-gagneurlab/tMAE	1.0.4	HEAD
+gagneurlab/OUTRIDER	1.20.1	1.20.1
+gagneurlab/FRASER	1.99.4	1.99.4
+gagneurlab/tMAE	1.0.4	1.0.4
 VariantAnnotation		
 rmarkdown		
 knitr		

--- a/drop/requirementsR.txt
+++ b/drop/requirementsR.txt
@@ -1,7 +1,7 @@
 package	min_version	max_version	ref
 devtools
 gagneurlab/OUTRIDER	1.17.2	1.17.2	HEAD
-gagneurlab/FRASER	1.99.1	1.99.3	HEAD
+c-mertes/FRASER	1.99.9	1.99.3	fix_strand_specific
 gagneurlab/tMAE	1.0.4	1.0.4	HEAD
 VariantAnnotation		
 rmarkdown		

--- a/drop/requirementsR.txt
+++ b/drop/requirementsR.txt
@@ -1,8 +1,8 @@
-package	min_version	max_version	ref
+package	version	ref
 devtools
-gagneurlab/OUTRIDER	1.17.2	1.17.2	HEAD
-c-mertes/FRASER	1.99.9	1.99.3	fix_strand_specific
-gagneurlab/tMAE	1.0.4	1.0.4	HEAD
+gagneurlab/OUTRIDER	1.22.0	HEAD
+gagneurlab/FRASER	2.0.0	HEAD
+gagneurlab/tMAE	1.0.4	HEAD
 VariantAnnotation		
 rmarkdown		
 knitr		

--- a/drop/template/Scripts/MonoallelicExpression/Overview.R
+++ b/drop/template/Scripts/MonoallelicExpression/Overview.R
@@ -86,7 +86,7 @@ qc_links <- sapply(qc_groups, function(v) build_link_list(
 #'
 
 #' ## Analyze Individual Results
-#+echo=FALSE
+#+ echo=FALSE
 # Read the first results table
 res_sample <- readRDS(snakemake@input$results_sample[[1]])
 sample <- unique(res_sample$ID)
@@ -95,7 +95,7 @@ library(tMAE)
 library(ggplot2)
 rare_column <- 'rare'
 if(any(is.na(res_sample$rare))) rare_column <- NULL
-#+echo=TRUE
+#+ echo=TRUE
 
 #' ### MA plot: fold change vs RNA coverage
 plotMA4MAE(res_sample, rare_column = rare_column,

--- a/drop/template/Scripts/Pipeline/SampleAnnotation.R
+++ b/drop/template/Scripts/Pipeline/SampleAnnotation.R
@@ -16,7 +16,7 @@
 #'    code_download: TRUE
 #'---
 
-#+echo=F
+#+ echo=F
 saveRDS(snakemake, snakemake@log$snakemake)
 
 suppressPackageStartupMessages({
@@ -76,7 +76,7 @@ unique(sa[,.(RNA_ID, DROP_GROUP)])$DROP_GROUP %>% strsplit(',') %>% unlist %>%
   table %>% barplot(xlab = 'DROP groups', ylab = 'Number of samples')
 
 # Obtain genes that overlap with HPO terms
-#+echo=F
+#+ echo=F
 if(!is.null(sa$HPO_TERMS) & !all(is.na(sa$HPO_TERMS)) & ! all(sa$HPO_TERMS == '')){
   sa2 <- sa[, .SD[1], by = RNA_ID]
   

--- a/drop/template/Snakefile
+++ b/drop/template/Snakefile
@@ -72,28 +72,35 @@ rule dependencyGraph:
 rule publish_local:
     shell: "rsync -Ort {config[htmlOutputPath]} {config[webDir]}"
 
-rule prepFasta_fa:
-    priority: 1
-    input:
-        "{path_to_ref}.fa"
-    output:
-        dict = "{path_to_ref}.dict" ,
-        fai = "{path_to_ref}.fa.fai"
+rule index_fa:
+    input: "{path_to_ref}.fa"
+    output: "{path_to_ref}.fa.fai"
     shell:
         """
-        samtools faidx {input} -o {output.fai}
-        gatk CreateSequenceDictionary -R {input} -O {output.dict}
+        samtools faidx {input} -o {output}
         """
 
-rule prepFasta_fasta:
-    priority: 1
-    input:
-        "{path_to_ref}.fasta"
-    output:
-        dict = "{path_to_ref}.dict" ,
-        fai = "{path_to_ref}.fasta.fai"
+rule dict_fa:
+    input: "{path_to_ref}.fa"
+    output: "{path_to_ref}.dict"
     shell:
         """
-        samtools faidx {input} -o {output.fai}
-        gatk CreateSequenceDictionary -R {input} -O {output.dict}
+        gatk CreateSequenceDictionary --REFERENCE {input} --OUTPUT {output}
         """
+
+rule index_fasta:
+    input: "{path_to_ref}.fasta"
+    output: "{path_to_ref}.fasta.fai"
+    shell:
+        """
+        samtools faidx {input} -o {output}
+        """
+
+rule dict_fasta:
+    input: "{path_to_ref}.fasta"
+    output: "{path_to_ref}.dict"
+    shell:
+        """
+        gatk CreateSequenceDictionary --REFERENCE {input} --OUTPUT {output}
+        """
+

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,10 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python==3.8
+  - python>=3.8
   - pip
   - drop
+  - snakemake>=5,<8
   - flake8
   - bioconductor-bsgenome.hsapiens.ucsc.hg19
 


### PR DESCRIPTION
- adapts DROP to use [FRASER 2.0.0](https://www.bioconductor.org/packages/release/bioc/html/FRASER.html) strand specific counting and results creation
- fixes error introduced by the new version of knitr (Issue #532)
- removes redundant rules to create dict and fai files in MAE pipeline
