### PR TITLE
Update GHA

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -13,6 +13,9 @@ jobs:
 
     - name: Setup environment with micromamba
       uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: environment.yml
+        cache-environment: true
 
     - name: Check micromamba install
       shell: bash -l {0}

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup environment with micromamba
-      uses: mamba-org/provision-with-micromamba@v10
+      uses: mamba-org/setup-micromamba@v1
 
     - name: Check micromamba install
       shell: bash -l {0}


### PR DESCRIPTION
DROP used `provision-with-micromamba`  in GHA, which has recently been [deprecated](https://github.com/mamba-org/provision-with-micromamba/releases/tag/v16). This PR migrates DROP GHA to [mamba-org/setup-micromamba](https://github.com/mamba-org/setup-micromamba).