### PR TITLE
Add requirement for DT

### DIFF
--- a/drop/requirementsR.txt
+++ b/drop/requirementsR.txt
@@ -1,5 +1,6 @@
 package	version	ref
 devtools
+DT
 gagneurlab/OUTRIDER	1.20.1	1.20.1
 gagneurlab/FRASER	1.99.4	1.99.4
 gagneurlab/tMAE	1.0.4	1.0.4


### PR DESCRIPTION
DT::datatable() is used throughout (e.g. drop/modules/aberrant-splicing-pipeline/Counting/00_define_datasets_from_anno.R but DT is not required. This fix adds DT.