### PR TITLE
Fix MAE by removing unneeded seqlevel conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ For more information on different installation options, refer to the
 
 ## What's new
 
+Version 1.6.0 contains a fix to a bug in the counting of the aberrant expression module ⚠️ . Please do not use v1.5.0.
+
 Version 1.5.0 contains the versions of OUTRIDER and FRASER that use the Optimal Hard Threshold procedure established by Gavish and Donoho, a deterministic approach to denoise low-rank matrices relying on singular value decomposition, to find the optimal autoencoder dimension instead of the grid search. This leads to a reduction in the run time of around 6-10 times. DROP supports mixing BAM files and external expression counts within the same group. This allows users to provide pre-computed expression counts for some samples while still using BAM files for splicing analysis. When both are available for a sample, external counts take priority for expression analysis, while BAM files are still used for splicing analysis.
 
-⚠️ Also, since this version, OUTRIDER and FRASER are released under `CC-BY-NC 4.0`, meaning a license is required for any commercial use. The commercial license is distributed by [OmicsDiscoveries](https://www.omicsdiscoveries.com). If you intend to use it for commercial purposes, please write to license@omicsdiscoveries.com.
+⚠️ Also, since this version, OUTRIDER and FRASER are released under `CC-BY-NC 4.0`, meaning a license is required for any commercial use. The commercial license is distributed by [OmicsDiscoveries](https://www.omicsdiscoveries.com). If you intend to use it for commercial purposes, please write to license@omicsdiscoveries.com. For the purposes of this license, commercial use includes any situation in which an entity receives payment from another entity for running DROP, regardless of the specific application.
 
 Version 1.4.0 fixes some bugs regarding the split reads counting for FRASER, which only affects cohorts containing samples with different strands (stranded forward, stranded reverse or unstranded). If your cohort contained samples with different strands, please rerun the AS module using version 1.4.0. In addition, due to snakemake updates affecting wBuild and the way we installed FRASER, installing DROP 1.3.3 no longer works. Version 1.3.4 fixes the FRASER version to ensure reproducibility and fixes certain scripts affected by the snakemake update. Running the pipeline with version 1.3.4 should provide the same outlier results as 1.3.3.
 
@@ -63,12 +65,11 @@ separate folder for each version. Moreover, DROP now allows users to provide lis
 
 `Snakemake v.7.8` introduced some changes in which changes in parameters can cause rules to be re-executed. More info [here](https://github.com/snakemake/snakemake/issues/1694). This affects DROP and causes certain rules in the AS and QC modules to be triggered even if they were already completed and there were no changes in the sample annotation or scripts. The workaround is to run DROP by adding the parameter `--rerun-triggers mtime`, e.g. `snakemake -n --rerun-triggers mtime` or `snakemake --cores 10 --rerun-triggers mtime`. We will investigate the rules in DROP to fix this.
 
-As of version 1.2.1 DROP has a new module that performs RNA-seq variant calling. The input are BAM files and the output either a single-sample or a multi-sample VCF file (option specified by the user) annotated with allele frequencies from gnomAD (if specified by the user). The sample annotation table does not need to be changed, but several new parameters in the config file have to be added and tuned. For more info, refer to the [documentation](https://gagneurlab-drop.readthedocs.io/en/latest/prepare.html#rna-variant-calling-dictionary).
-
-Also, as of version 1.2.1 the integration of external split and non-split counts to detect aberrant splicing is now possible. In a new column in the sample annotation, simply specify the directory containing the counts. For more info, refer to the [documentation](https://gagneurlab-drop.readthedocs.io/en/latest/prepare.html#external-count-examples).
+As of version 1.2.1 DROP has a new module that performs RNA-seq variant calling. The input are BAM files and the output either a single-sample or a multi-sample VCF file (option specified by the user) annotated with allele frequencies from gnomAD (if specified by the user). The sample annotation table does not need to be changed, but several new parameters in the config file have to be added and tuned. For more info, refer to the [documentation](https://gagneurlab-drop.readthedocs.io/en/latest/prepare.html#rna-variant-calling-dictionary). Also, as of version 1.2.1 the integration of external split and non-split counts to detect aberrant splicing is now possible. In a new column in the sample annotation, simply specify the directory containing the counts. For more info, refer to the [documentation](https://gagneurlab-drop.readthedocs.io/en/latest/prepare.html#external-count-examples).
 
 ## Set up a custom project
 Install the drop module according to [installation](#installation) and initialize the project in a custom project directory.
+
 ### Prepare the input data
 Create a sample annotation table that contains the sample IDs, file locations and other information necessary for the pipeline.
 Edit the config file to set the correct file path of the sample annotation and locations of non-sample-specific input files.
@@ -121,6 +122,6 @@ For the complete set of tools used by DROP (e.g. for counting), see the [manuscr
 
 ## Acknowledgements and Funding
 
-The DROP team is composed of members from the Gagneur lab at the Department of Informatics and the School of Medicine of the Technical University of Munich (TUM) and The German Human Genome-Phenome Archive (GHGA). The team has been funded by the German Bundesministerium für Bildung und Forschung (BMBF) through the e:Med Networking fonds AbCD-Net and the ERA PerMed project PerMiM. 
+The DROP team is composed of members from the Gagneur lab at the Department of Informatics and the School of Medicine of the Technical University of Munich (TUM) and The German Human Genome-Phenome Archive (GHGA). The team has been funded by the German Bundesministerium für Bildung und Forschung (BMBF) through the e:Med Networking fund AbCD-Net and the ERA PerMed project PerMiM. 
 In addition, the [OmicsDiscoveries](https://www.omicsdiscoveries.com/) team has contributed to DROP since September 2024.
 We would like to thank all the users for their feedback.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = '2020, Michaela Müller'
 author = 'Michaela Müller'
 
 # The full version, including alpha/beta/rc tags
-release_ = '1.5.0'
+release_ = '1.6.0'
 
 
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -20,7 +20,7 @@ Install the latest version and use the full path in the following command to ins
 
 .. code-block:: bash
 
-    mamba env create -f DROP_1.5.0.yaml
+    mamba env create -f DROP_1.6.0.yaml
 
 
 Installation time: ~ 10min

--- a/drop/__init__.py
+++ b/drop/__init__.py
@@ -5,4 +5,4 @@ from . import utils
 from . import demo
 
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"

--- a/drop/cli.py
+++ b/drop/cli.py
@@ -17,7 +17,7 @@ click_log.basic_config(logger)
 
 @click.group(invoke_without_command=True)
 @click_log.simple_verbosity_option(logger)
-@click.version_option('1.5.0',prog_name='drop')
+@click.version_option('1.6.0',prog_name='drop')
 
 def main():
     ctx = click.get_current_context()

--- a/drop/modules/mae-pipeline/MAE/Results.R
+++ b/drop/modules/mae-pipeline/MAE/Results.R
@@ -43,9 +43,7 @@ suppressPackageStartupMessages({
 rmae <- lapply(snakemake@input$mae_res, fread) %>% rbindlist()
 
 # re-factor contig and have all as UCSC chr style
-rmae[, contig := as.character(contig)]
-rmae[!grepl("chr",contig), contig := paste0("chr",contig)]
-rmae$contig <- factor(rmae$contig)
+seqlevelsStyle(rmae$contig) <- 'UCSC'
 
 # Convert results into GRanges
 rmae_ranges <- GRanges(seqnames = rmae$contig, 
@@ -57,7 +55,7 @@ gene_annot_dt <- fread(snakemake@input$gene_name_mapping)
 gene_annot_ranges <- GRanges(seqnames = gene_annot_dt$seqnames, 
                              IRanges(start = gene_annot_dt$start, end = gene_annot_dt$end), 
                              strand = gene_annot_dt$strand)
-gene_annot_ranges <- keepStandardChromosomes(gene_annot_ranges, pruning.mode = 'coarse')
+# gene_annot_ranges <- keepStandardChromosomes(gene_annot_ranges, pruning.mode = 'coarse')
 
 # Keep the chr style of the annotation in case the results contain different styles
 seqlevelsStyle(rmae_ranges) <- seqlevelsStyle(gene_annot_ranges)

--- a/drop/modules/mae-pipeline/MAE/Results.R
+++ b/drop/modules/mae-pipeline/MAE/Results.R
@@ -42,7 +42,7 @@ suppressPackageStartupMessages({
 # Read all MAE results files
 rmae <- lapply(snakemake@input$mae_res, fread) %>% rbindlist()
 
-# re-factor contig and have all as UCSC chr style
+# Force UCSC chr style
 seqlevelsStyle(rmae$contig) <- 'UCSC'
 
 # Convert results into GRanges

--- a/drop/modules/mae-pipeline/MAE/Results.R
+++ b/drop/modules/mae-pipeline/MAE/Results.R
@@ -42,9 +42,6 @@ suppressPackageStartupMessages({
 # Read all MAE results files
 rmae <- lapply(snakemake@input$mae_res, fread) %>% rbindlist()
 
-# Force UCSC chr style
-seqlevelsStyle(rmae$contig) <- 'UCSC'
-
 # Convert results into GRanges
 rmae_ranges <- GRanges(seqnames = rmae$contig, 
                        IRanges(start = rmae$position, end = rmae$position), 
@@ -55,7 +52,6 @@ gene_annot_dt <- fread(snakemake@input$gene_name_mapping)
 gene_annot_ranges <- GRanges(seqnames = gene_annot_dt$seqnames, 
                              IRanges(start = gene_annot_dt$start, end = gene_annot_dt$end), 
                              strand = gene_annot_dt$strand)
-# gene_annot_ranges <- keepStandardChromosomes(gene_annot_ranges, pruning.mode = 'coarse')
 
 # Keep the chr style of the annotation in case the results contain different styles
 seqlevelsStyle(rmae_ranges) <- seqlevelsStyle(gene_annot_ranges)
@@ -143,10 +139,10 @@ melt_dt[variable == 'N_MAE_ALT_RARE', variable := '+MAE for ALT\n& rare']
 #' a cascade plot that shows a progression of added filters  
 #'   - >10 counts: only variants supported by more than 10 counts
 #'   - +MAE: and shows mono allelic expression
-#'   - +MAE for REF : the monoallelic expression favors the reference allele
-#'   - +MAE for ALT : the monoallelic expression favors the alternative allele
+#'   - +MAE for REF :the monoallelic expression favors the reference allele
+#'   - +MAE for ALT :the monoallelic expression favors the alternative allele
 #'   - rare: 
-#'     - if `add_AF` is set to true in config file must meet minimum AF set by the config value `max_AF`
+#'     - if `add_AF` is set to true in the config file must meet the minimum AF set by the config value `max_AF`
 #'     - must meet the inner-cohort frequency `maxVarFreqCohort` cutoff
 
 ggplot(melt_dt, aes(variable, value)) + geom_boxplot() +

--- a/drop/modules/mae-pipeline/MAE/Results.R
+++ b/drop/modules/mae-pipeline/MAE/Results.R
@@ -84,7 +84,7 @@ maxCohortFreq <- snakemake@params$maxCohortFreq
 res[, N_var := .N, by = .(gene_name, contig, position)]
 res[, cohort_freq := round(N_var / uniqueN(ID), 3)]
 
-res[, rare := (rare | is.na(rare)) & cohort_freq <= maxCohortFreq] 
+res[, rare := (isTRUE(rare) | is.na(rare)) & cohort_freq <= maxCohortFreq] 
 
 # Add significance columns
 allelicRatioCutoff <- snakemake@params$allelicRatioCutoff

--- a/drop/modules/mae-pipeline/MAE/gene_name_mapping.R
+++ b/drop/modules/mae-pipeline/MAE/gene_name_mapping.R
@@ -22,7 +22,7 @@ suppressPackageStartupMessages({
 
 gtf_dt <- import(snakemake@input$gtf) %>% as.data.table
 if (!"gene_name" %in% colnames(gtf_dt)) {
-  gtf_dt[gene_name := gene_id]
+  gtf_dt[, gene_name := gene_id]
 }
 if('gene_biotype' %in% colnames(gtf_dt))
    setnames(gtf_dt, 'gene_biotype', 'gene_type')

--- a/environment.yml
+++ b/environment.yml
@@ -3,10 +3,10 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python>=3.8
+  - python>=3.11
   - r-base>=4.4
   - pip
-  - pandas>=2.2
+  - pandas>=3.0
   - drop
   - snakemake>=5,<8
   - flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 
-current_version = 1.5.0
+current_version = 1.6.0
 commit = True
 
 [bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ for (path, directories, filenames) in os.walk('drop/'):
 
 setuptools.setup(
     name="drop",
-    version="1.5.0",
-    author="Vicente A. Yépez, Michaela Müller, Nicholas H. Smith, Daniela Klaproth-Andrade, Luise Schuller, Ines Scheller, Christian Mertes <mertes@in.tum.de>, Julien Gagneur <gagneur@in.tum.de>",
+    version="1.6.0",
+    author="Vicente A. Yépez, Michaela Müller, Nicholas H. Smith, Ata Jadid Ahari, Daniela Klaproth-Andrade, Luise Schuller, Ines Scheller, Christian Mertes <mertes@in.tum.de>, Julien Gagneur <gagneur@in.tum.de>",
     author_email="yepez@in.tum.de",
     description="Detection of RNA Outlier Pipeline",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
     'python-dateutil',
     'pandoc',
     'graphviz',
-    'pandas>=2.2',
+    'pandas>=3.0',
 ]
 
 extra_files = []

--- a/tests/config/test_SampleAnnotation.py
+++ b/tests/config/test_SampleAnnotation.py
@@ -13,7 +13,7 @@ class Test_SampleAnnotation:
 
     def test_mapping(self, sampleAnnotation):
         # ID mappings/groups
-        assert sampleAnnotation.idMapping.shape == (14, 2)
+        assert sampleAnnotation.idMapping.shape == (10, 2) # Test unique RNA - DNA pairs
         assert sampleAnnotation.sampleFileMapping.shape == (24, 4)
         true_mapping = {'batch_0': 1, 'batch_1': 2, 'mae': 3, 'outrider_external': 8, 'outrider': 10,
                 'fraser': 10,'fraser_external':8}


### PR DESCRIPTION
Fixes a bug that was introduced when removing the non canonical chrs and was causing some gene names to be incorrectly annotated in the MAE module